### PR TITLE
Add findbugs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,5 @@ Para visualizar os logs da aplicação a partir do container: `docker logs -f mo
 * Separar testes unitários dos testes integrados
 * Corrigir os testes ignorados
 * Corrigir Code Style
-* Adicionar plugin do FindBugs
 * Revisar dependências (ver, por exemplo, se é mesmo necessário ter o GSON ou modelmapper)
 * Usar objectmapper como component: `compile('com.fasterxml.jackson.datatype:jackson-datatype-jdk8')`

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,13 @@ apply plugin: 'jacoco'
 apply plugin: 'docker'
 apply plugin: 'findbugs'
 
+findbugs {
+    sourceSets = [sourceSets.main]
+    ignoreFailures = true
+    effort = "default"
+    reportLevel = "high"
+}
+
 version = '4.0.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
@@ -38,7 +45,6 @@ dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'
     compile 'com.squareup.okhttp3:okhttp:3.8.1'
-
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'br.com.six2six:fixture-factory:3.1.0'
 }
@@ -72,3 +78,4 @@ task buildDocker(type: Docker, dependsOn: build) {
         }
     }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'jacoco'
 apply plugin: 'docker'
+apply plugin: 'findbugs'
 
 version = '4.0.0-SNAPSHOT'
 sourceCompatibility = 1.8

--- a/src/main/java/br/com/concrete/mock/generic/service/impl/EndpointBackupServiceFile.java
+++ b/src/main/java/br/com/concrete/mock/generic/service/impl/EndpointBackupServiceFile.java
@@ -12,6 +12,8 @@ import br.com.concrete.mock.infra.component.impl.JsonFormatterPretty;
 import br.com.concrete.mock.infra.property.FileExtensionProperty;
 import br.com.concrete.mock.infra.property.FileProperty;
 import com.google.gson.Gson;
+import java.nio.charset.Charset;
+import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,8 +72,7 @@ public class EndpointBackupServiceFile implements EndpointBackupService {
 
         try {
             Files.createDirectories(Paths.get(pathName));
-            Files.write(Paths.get(fileName), endpointJson.getBytes());
-
+            Files.write(Paths.get(fileName), Arrays.asList(endpointJson), Charset.defaultCharset());
             LOGGER.info("Backup into " + fileName);
         } catch (IOException e) {
             LOGGER.error("Cannot backup endpoint {}", e);


### PR DESCRIPTION
Fix #4 

Add findbugs plugins (https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html) for detecting nasty errors. Current level is set to default, as a best balance between effort and time/memory