### PR TITLE
Permite variáveis no json a partir de parametros do request

### DIFF
--- a/mocks-test/get/guests/132/1.json
+++ b/mocks-test/get/guests/132/1.json
@@ -11,7 +11,10 @@
       },
       {
         "cc": "31",
-        "ca": "32"
+        "ca": "32",
+        "name":"#{{param:name}}",
+        "surname":"#{{param:surname}}"
+
       }
     ]
   }

--- a/src/main/java/br/com/elementalsource/mock/infra/component/JsonValueCompiler.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/JsonValueCompiler.java
@@ -1,8 +1,15 @@
 package br.com.elementalsource.mock.infra.component;
 
+import java.util.function.Function;
+
 @FunctionalInterface
-public interface JsonValueCompiler {
+public interface JsonValueCompiler extends Function<String, String> {
 
     String compile(final String json);
+
+    @Override
+    default String apply(String s) {
+        return compile(s);
+    }
 
 }

--- a/src/main/java/br/com/elementalsource/mock/infra/component/impl/DaysAgoJsonValueCompilerImpl.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/impl/DaysAgoJsonValueCompilerImpl.java
@@ -9,13 +9,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Component
-public class JsonValueCompilerImpl implements JsonValueCompiler {
+public class DaysAgoJsonValueCompilerImpl implements JsonValueCompiler {
+
+    // http://regexr.com/3f7lq
+    private static final Pattern PATTERN = Pattern.compile("\\#\\{\\{(\\d)+daysAgo:([a-z]+?.*?[a-z]+?)\\}\\}", Pattern.CASE_INSENSITIVE);
 
     @Override
     public String compile(String json) {
-        // http://regexr.com/3f7lq
-        final Pattern p = Pattern.compile("\\#\\{\\{(\\d)+daysAgo:([a-z]+?.*?[a-z]+?)\\}\\}", Pattern.CASE_INSENSITIVE);
-        final Matcher m = p.matcher(json);
+
+        final Matcher m = PATTERN.matcher(json);
 
         final StringBuffer sb = new StringBuffer();
         while (m.find()) {

--- a/src/main/java/br/com/elementalsource/mock/infra/component/impl/ParameterJsonValueCompilerImpl.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/impl/ParameterJsonValueCompilerImpl.java
@@ -1,0 +1,43 @@
+package br.com.elementalsource.mock.infra.component.impl;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import br.com.elementalsource.mock.infra.component.JsonValueCompiler;
+import reactor.ipc.netty.http.server.HttpServerRequest;
+
+@Component
+public class ParameterJsonValueCompilerImpl implements JsonValueCompiler {
+
+    @Autowired
+    private HttpServletRequest request;
+
+    //https://regexr.com/3sj41
+    private static final Pattern PATTERN = Pattern.compile("\\#\\{\\{param:(\\w+)\\}\\}", Pattern.CASE_INSENSITIVE);
+
+    @Override
+    public String compile(String json) {
+
+        final Matcher m = PATTERN.matcher(json);
+
+        final StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String paramName = m.group(1);
+            String paramValue = request.getParameter(paramName);
+
+            if(paramValue != null){
+                m.appendReplacement(sb, paramValue);
+            }
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+}

--- a/src/test/java/br/com/elementalsource/mock/infra/component/impl/DaysAgoJsonValueCompilerImplTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/impl/DaysAgoJsonValueCompilerImplTest.java
@@ -11,10 +11,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @RunWith(MockitoJUnitRunner.class)
-public class JsonValueCompilerImplTest {
+public class DaysAgoJsonValueCompilerImplTest {
 
     @InjectMocks
-    private JsonValueCompilerImpl jsonValueCompiler;
+    private DaysAgoJsonValueCompilerImpl jsonValueCompiler;
 
     @Test
     public void shouldBeEqualWhenNotExistVariables() throws JSONException {

--- a/src/test/java/br/com/elementalsource/mock/infra/component/impl/ParameterJsonValueCompilerImplTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/impl/ParameterJsonValueCompilerImplTest.java
@@ -1,0 +1,35 @@
+package br.com.elementalsource.mock.infra.component.impl;
+
+import static org.junit.Assert.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ParameterJsonValueCompilerImplTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @InjectMocks
+    private ParameterJsonValueCompilerImpl subject;
+
+    @Test
+    public void shouldReplaceManyPatternsAtSameTimeInAJson(){
+        String json = "{\"value\":\"xxx\", \"name\":\"#{{param:name}}\", \"other\":\"#{{param:other}}\"}";
+
+        Mockito.when(request.getParameter("name")).thenReturn("John");
+        Mockito.when(request.getParameter("other")).thenReturn("Snow");
+
+        String result = subject.compile(json);
+        assertEquals("{\"value\":\"xxx\", \"name\":\"John\", \"other\":\"Snow\"}" , result);
+
+    }
+
+}


### PR DESCRIPTION

## Changelog
- Permite valores variáveis nas respostas a partir de parâmetros do request.

Exemplo: 
```
{
"name":"#{{param:name}}",
"surname":"#{{param:surame}}"
}
```

Com o request `http:localhost:9090/bla?name=John&surname=Snow` vai produzir o json:

```
{
"name":"John",
"surname":"Snow"
}
```

Aberto a sugestões e code review