### PR TITLE
Adiciona suporte a parametros com multiplos valores & múltiplas configs simultâneas

### DIFF
--- a/src/main/java/br/com/elementalsource/mock/generic/api/v1/controller/GenericApiController.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/api/v1/controller/GenericApiController.java
@@ -33,20 +33,22 @@ public class GenericApiController {
     private final RequestMapper requestMapper;
     private final JsonFormatter jsonFormatter;
     private final RequestFormatter requestFormatter;
+    private final Gson gson;
 
     @Autowired
     public GenericApiController(GenericApiService genericApiService, RequestMapper requestMapper,
-                                JsonFormatter jsonFormatter, RequestFormatter requestFormatter) {
+                                JsonFormatter jsonFormatter, RequestFormatter requestFormatter, Gson gson) {
         this.genericApiService = genericApiService;
         this.requestMapper = requestMapper;
         this.jsonFormatter = jsonFormatter;
         this.requestFormatter = requestFormatter;
+        this.gson = gson;
     }
 
     private void logRequest(final HttpServletRequest request, final Optional<Object> requestBody) {
         LOGGER.info(requestFormatter.generateLog(request, requestBody));
         LOGGER.info("Headers: " + genericApiService.getHeaders(request));
-        requestBody.ifPresent(body -> logJson(new Gson().toJson(body)));
+        requestBody.ifPresent(body -> logJson(gson.toJson(body)));
     }
 
     private void logJson(final String jsonString) {

--- a/src/main/java/br/com/elementalsource/mock/generic/api/v1/mapper/RequestMapper.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/api/v1/mapper/RequestMapper.java
@@ -3,6 +3,8 @@ package br.com.elementalsource.mock.generic.api.v1.mapper;
 import br.com.elementalsource.mock.generic.mapper.HeaderMapper;
 import br.com.elementalsource.mock.generic.model.Request;
 import br.com.elementalsource.mock.generic.mapper.QueryMapper;
+import br.com.elementalsource.mock.infra.property.ApiProperty;
+
 import com.google.gson.Gson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -14,15 +16,15 @@ import java.util.Optional;
 @Component
 public class RequestMapper {
 
-    private static final Gson GSON = new Gson();
-
     private final QueryMapper queryMapper;
     private final HeaderMapper headerMapper;
+    private final Gson gson;
 
     @Autowired
-    public RequestMapper(QueryMapper queryMapper, HeaderMapper headerMapper) {
+    public RequestMapper(QueryMapper queryMapper, HeaderMapper headerMapper, Gson gson) {
         this.queryMapper = queryMapper;
         this.headerMapper = headerMapper;
+        this.gson = gson;
     }
 
     private Request.Builder mapperBuilder(final HttpServletRequest request) {
@@ -40,7 +42,7 @@ public class RequestMapper {
         final Request.Builder requestMockBuilder = mapperBuilder(request);
 
         return requestBody
-                .map(requestBodyJson -> requestMockBuilder.withBody(Optional.ofNullable(GSON.toJson(requestBodyJson))))
+                .map(requestBodyJson -> requestMockBuilder.withBody(Optional.ofNullable(gson.toJson(requestBodyJson))))
                 .orElse(requestMockBuilder)
                 .build();
     }

--- a/src/main/java/br/com/elementalsource/mock/generic/mapper/EndpointMapper.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/mapper/EndpointMapper.java
@@ -18,17 +18,19 @@ public class EndpointMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(EndpointMapper.class);
 
     private final FileJsonReader fileJsonReader;
+    private final Gson gson;
 
     @Autowired
-    public EndpointMapper(FileJsonReader fileJsonReader) {
+    public EndpointMapper(FileJsonReader fileJsonReader, Gson gson) {
         this.fileJsonReader = fileJsonReader;
+        this.gson = gson;
     }
 
     public Optional<Endpoint> mapper(RequestMethod requestMethod, String requestUrl, String fileName) {
         try {
             return fileJsonReader
                     .getJsonByFileName(fileName)
-                    .map(endpointDtoJson -> new Gson().fromJson(endpointDtoJson, EndpointDto.class))
+                    .map(endpointDtoJson -> gson.fromJson(endpointDtoJson, EndpointDto.class))
                     .map(endpointDto -> endpointDto.toModel(requestMethod, requestUrl))
                     .map(endpoint -> new Endpoint.Builder(endpoint).withId(fileName).build());
         } catch (IOException e) {

--- a/src/main/java/br/com/elementalsource/mock/generic/mapper/QueryDecoder.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/mapper/QueryDecoder.java
@@ -9,39 +9,56 @@ import org.springframework.context.annotation.Configuration;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static java.util.Map.*;
 import static java.util.stream.Collectors.toMap;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 @Configuration
 public class QueryDecoder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryDecoder.class);
 
+    static DecoderFunction identity = map -> map;
+
     @FunctionalInterface
     interface DecoderFunction {
-        Map<String, String> decode(Map<String, String> map);
+        Multimap<String,String> decode(Multimap<String, String> map);
     }
 
     @Bean
     public DecoderFunction decoderFactoryImplementation(@Value("${decoder.characterEncoding:}") final String characterEncoding) {
         if (StringUtils.isBlank(characterEncoding)) {
-            return parameters -> parameters;
+            return identity;
         } else {
-            final Function<Map.Entry<String, String>, String> decodeFunction = value -> {
-                try {
-                    return URLDecoder.decode(value.getValue(), characterEncoding);
-                } catch (UnsupportedEncodingException e) {
-                    LOGGER.error("Cannot decode URL {}", e);
-                    return value.getValue();
-                }
+            return parametersMap -> {
+                Multimap newMap = ArrayListMultimap.create();
+
+                parametersMap.asMap().forEach((key,values) -> {
+                    for (String v: values) {
+                        newMap.put(key, decodeValue(v, characterEncoding));
+                    }
+                });
+
+                return parametersMap;
             };
 
-            return parameters -> parameters.
-                    entrySet().
-                    stream().
-                    collect(toMap(Map.Entry::getKey, decodeFunction));
+        }
+    }
+
+    private String decodeValue(String value, String characterEncoding){
+        try {
+            return URLDecoder.decode(value, characterEncoding);
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.error("Cannot decode URL {}", e);
+            return value;
         }
     }
 

--- a/src/main/java/br/com/elementalsource/mock/generic/mapper/QueryMapper.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/mapper/QueryMapper.java
@@ -9,9 +9,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 @Component
 public class QueryMapper {
@@ -24,7 +27,7 @@ public class QueryMapper {
         this.decoderFunction = decoderFunction;
     }
 
-    public Optional<Map<String, String>> mapper(final String queryRequest) {
+    public Optional<Multimap<String, String>> mapper(final String queryRequest) {
         return Optional
                 .ofNullable(queryRequest)
                 .map(query -> {
@@ -48,8 +51,14 @@ public class QueryMapper {
 
                 })
                 .filter(parameters -> !parameters.isEmpty())
-                .map(MultiValueMap::toSingleValueMap)
+                .map(this::asModifiableMap)
                 .map(decoderFunction::decode);
+    }
+
+    private Multimap<String, String> asModifiableMap(MultiValueMap<String,String> map){
+        Multimap<String, String> multimap = ArrayListMultimap.create();
+        map.forEach(multimap::putAll);
+        return multimap;
     }
 
 }

--- a/src/main/java/br/com/elementalsource/mock/generic/mapper/RequestDto.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/mapper/RequestDto.java
@@ -2,27 +2,33 @@ package br.com.elementalsource.mock.generic.mapper;
 
 import br.com.elementalsource.mock.generic.model.Request;
 import br.com.elementalsource.mock.infra.component.FromJsonStringToObjectConverter;
+import br.com.elementalsource.mock.infra.component.gson.GsonFactory;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class RequestDto implements Serializable {
 
-    private static final Gson GSON = new Gson();
+    private static final Gson GSON = new GsonFactory().gson();
 
     private final HttpHeaders headers;
-    private final Map<String, String> query;
+    private final Multimap<String, String> query;
     private final JsonElement body;
 
     @JsonCreator
-    public RequestDto(@JsonProperty("headers") HttpHeaders headers, @JsonProperty("query") Map<String, String> query, @JsonProperty("body") JsonElement body) {
+    public RequestDto(@JsonProperty("headers") HttpHeaders headers, @JsonProperty("query") Multimap<String, String> query, @JsonProperty("body") JsonElement body) {
         this.headers = headers;
         this.query = query;
         this.body = body;
@@ -41,7 +47,7 @@ public class RequestDto implements Serializable {
         return headers;
     }
 
-    public Map<String, String> getQuery() {
+    public Multimap<String, String> getQuery() {
         return query;
     }
 
@@ -50,6 +56,7 @@ public class RequestDto implements Serializable {
     }
 
     public Request toModel(RequestMethod method, String uri) {
+
         return new Request.Builder(method, uri)
                 .withHeader(headers)
                 .withQuery(query)

--- a/src/main/java/br/com/elementalsource/mock/generic/mapper/ResponseDto.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/mapper/ResponseDto.java
@@ -2,6 +2,7 @@ package br.com.elementalsource.mock.generic.mapper;
 
 import br.com.elementalsource.mock.generic.model.Response;
 import br.com.elementalsource.mock.infra.component.FromJsonStringToObjectConverter;
+import br.com.elementalsource.mock.infra.component.gson.GsonFactory;
 import br.com.elementalsource.mock.infra.exception.impl.ApiApplicationException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +15,7 @@ import java.util.Optional;
 
 public class ResponseDto implements Serializable {
 
-    private static final Gson GSON = new Gson();
+    private static final Gson GSON = new GsonFactory().gson();
 
     private final JsonElement body;
     private final Integer httpStatus;

--- a/src/main/java/br/com/elementalsource/mock/generic/model/Endpoint.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/model/Endpoint.java
@@ -1,5 +1,6 @@
 package br.com.elementalsource.mock.generic.model;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Multimap;
 
 public class Endpoint implements Comparable<Endpoint> {
 
@@ -95,7 +97,7 @@ public class Endpoint implements Comparable<Endpoint> {
 			this.response = response;
 		}
 
-		public Builder withRequest(Optional<Map<String, String>> requestQuery, Optional<String> requestBody) {
+		public Builder withRequest(Optional<Multimap<String, String>> requestQuery, Optional<String> requestBody) {
 			return withRequest(new Request.Builder(this.request).withQuery(requestQuery).withBody(requestBody).build());
 		}
 

--- a/src/main/java/br/com/elementalsource/mock/generic/model/Request.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/model/Request.java
@@ -6,9 +6,12 @@ import br.com.elementalsource.mock.infra.exception.impl.JsonApiApplicationExcept
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import com.google.common.collect.Multimap;
 
 public class Request implements Comparable<Request> {
 
@@ -17,7 +20,7 @@ public class Request implements Comparable<Request> {
     private RequestMethod method;
     private String uri;
     private Optional<HttpHeaders> headers;
-    private Optional<Map<String, String>> query;
+    private Optional<Multimap<String, String>> query;
     private Optional<String> body;
 
     private Request() {
@@ -44,7 +47,7 @@ public class Request implements Comparable<Request> {
         return headers;
     }
 
-    public Optional<Map<String, String>> getQuery() {
+    public Optional<Multimap<String, String>> getQuery() {
         return query;
     }
 
@@ -54,7 +57,7 @@ public class Request implements Comparable<Request> {
 
     public Integer countQueryFields() {
         return getQuery()
-                .map(Map::size)
+                .map(Multimap::size)
                 .orElse(0);
     }
 
@@ -142,11 +145,11 @@ public class Request implements Comparable<Request> {
             return this;
         }
 
-        public Builder withQuery(Map<String, String> query) {
+        public Builder withQuery(Multimap<String, String> query) {
             return withQuery(Optional.ofNullable(query));
         }
 
-        public Builder withQuery(Optional<Map<String, String>> query) {
+        public Builder withQuery(Optional<Multimap<String, String>> query) {
             instance.query = query;
             return this;
         }

--- a/src/main/java/br/com/elementalsource/mock/generic/repository/EndpointRepository.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/repository/EndpointRepository.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 
 public interface EndpointRepository {
 
-    Collection<Endpoint> getByMethodAndUri(RequestMethod requestMethod, String pathUri);
+    Collection<Endpoint> getAllByRequest(Request request);
 
-    Optional<Endpoint> getByMethodAndRequest(Request request);
+    Optional<Endpoint> getByRequest(Request request);
 
 }

--- a/src/main/java/br/com/elementalsource/mock/generic/repository/impl/EndpointFileFilterQuery.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/repository/impl/EndpointFileFilterQuery.java
@@ -5,11 +5,14 @@ import br.com.elementalsource.mock.generic.model.Endpoint;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.collect.Multimap;
+
 @Component
-class EndpointFileFilterQuery implements EndpointFileFilter<Optional<Map<String, String>>> {
+class EndpointFileFilterQuery implements EndpointFileFilter<Optional<Multimap<String, String>>> {
 
     private final CompareMap compareMap;
 
@@ -19,7 +22,7 @@ class EndpointFileFilterQuery implements EndpointFileFilter<Optional<Map<String,
     }
 
     @Override
-    public Boolean apply(Endpoint endpoint, Optional<Map<String, String>> request) {
+    public Boolean apply(Endpoint endpoint, Optional<Multimap<String, String>> request) {
         return request
                 .map(requestQuery ->
                         endpoint

--- a/src/main/java/br/com/elementalsource/mock/generic/repository/impl/EndpointRepositoryBase.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/repository/impl/EndpointRepositoryBase.java
@@ -39,21 +39,24 @@ public class EndpointRepositoryBase implements EndpointRepository {
     }
 
     @Override
-    public Collection<Endpoint> getByMethodAndUri(RequestMethod requestMethod, String requestUrl) {
-        return ImmutableList.copyOf(getByMethodAndUriMutable(requestMethod, requestUrl));
+    public Collection<Endpoint> getAllByRequest(Request request) {
+        return ImmutableList.copyOf(getByMethodAndUriMutable(request));
     }
 
     @Override
-    public Optional<Endpoint> getByMethodAndRequest(Request request) {
-        return getByMethodAndUri(request.getMethod(), request.getUri())
+    public Optional<Endpoint> getByRequest(Request request) {
+        return getAllByRequest(request)
                 .stream()
                 .sorted()
                 .filter(endpointMock -> endpointFileFilterRequest.apply(endpointMock, request))
                 .findFirst();
     }
 
-    private List<Endpoint> getByMethodAndUriMutable(RequestMethod requestMethod, String requestUrl) {
-        final String basePath = baseFileNameBuilder.buildPath(requestMethod, requestUrl);
+    private List<Endpoint> getByMethodAndUriMutable(Request request) {
+        RequestMethod requestMethod = request.getMethod();
+        String requestUrl = request.getUri();
+
+        final String basePath = baseFileNameBuilder.buildPath(request);
 
         final Path start = Paths.get(basePath);
         if (!Files.exists(start)) {

--- a/src/main/java/br/com/elementalsource/mock/generic/repository/impl/ExistingFiles.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/repository/impl/ExistingFiles.java
@@ -26,7 +26,7 @@ public class ExistingFiles {
 
 	@PostConstruct
 	public void setup() throws IOException {
-		String fileBase = fileProperty.getFileBase();
+		String fileBase = fileProperty.getRootPath();
 		existingFiles = Files.walk(Paths.get(fileBase))
 				.filter(Files::isRegularFile)
 				.map(Path::getParent)
@@ -40,4 +40,16 @@ public class ExistingFiles {
 	public List<ExistingFile> getExistingFiles(){
 		return existingFiles;
 	}
+
+	public static void main(String[] args) throws IOException {
+		Files.walk(Paths.get("mocks-test"))
+				.filter(Files::isRegularFile)
+				.map(Path::getParent)
+				.map(Path::toString)
+				.map(ExistingFile::new)
+				.sorted()
+				.distinct()
+				.forEach(System.out::println);
+	}
+
 }

--- a/src/main/java/br/com/elementalsource/mock/generic/service/EndpointBackupService.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/service/EndpointBackupService.java
@@ -6,6 +6,4 @@ public interface EndpointBackupService {
 
     void doBackup(Endpoint endpoint);
 
-    void cleanAllBackupData(); // dangerous
-
 }

--- a/src/main/java/br/com/elementalsource/mock/generic/service/impl/GenericApiServiceImpl.java
+++ b/src/main/java/br/com/elementalsource/mock/generic/service/impl/GenericApiServiceImpl.java
@@ -42,7 +42,7 @@ public class GenericApiServiceImpl implements GenericApiService {
     }
 
     private Optional<Endpoint> getEndpoint(Request request) {
-        return endpointRepository.getByMethodAndRequest(request);
+        return endpointRepository.getByRequest(request);
     }
 
     // TODO talvez extrair para uma classe

--- a/src/main/java/br/com/elementalsource/mock/infra/component/CompareJson.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/CompareJson.java
@@ -1,11 +1,13 @@
 package br.com.elementalsource.mock.infra.component;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 @Component
 public class CompareJson {
@@ -20,20 +22,65 @@ public class CompareJson {
     public Boolean isEquivalent(String jsonKey, String jsonToCompare) {
         final HashMap<String, Object> keys = convertJson.apply(jsonKey);
         final HashMap<String, Object> toCompare = convertJson.apply(jsonToCompare);
+        return compareMaps(keys, toCompare);
+    }
 
+    private boolean compareMaps(Map<String, Object> keys, Map<String, Object> toCompare) {
         for (Object entrySet : keys.entrySet()) {
             Map.Entry entry = (Map.Entry) entrySet;
+            final Object value = entry.getValue();
             final Object valueCompare = toCompare.get(entry.getKey());
 
-            if(valueCompare instanceof LinkedHashMap && entry.getValue() instanceof LinkedHashMap){
-                return ((LinkedHashMap)valueCompare).size() == ((LinkedHashMap) entry.getValue()).size();
-            }
-
-            if (!entry.getValue().equals(valueCompare)) {
+            if(valueCompare instanceof Map && value instanceof Map){
+                boolean compareResult = compareMaps((Map)value, (Map)valueCompare);
+                if(compareResult == false) {
+                    return false;
+                }
+            } else if (valueCompare instanceof List && value instanceof List) {
+                boolean compareResult = compareLists((List)value, (List)valueCompare);
+                if(compareResult == false) {
+                    return false;
+                }
+            } else if (!entry.getValue().equals(valueCompare)) {
                 return false;
             }
         }
 
+        return true;
+    }
+
+    private boolean compareLists(List list, List toCompare) {
+		List first = new ArrayList<>(list);
+		List second = new ArrayList<>(toCompare);
+        for (int i = 0; i < first.size(); i++) {
+            final Object value = first.get(i);
+			boolean compareResult = false;
+			Iterator iterator = second.iterator();
+			while(iterator.hasNext()) {
+				final Object valueCompare = iterator.next();
+				if(valueCompare instanceof List && value instanceof List) {
+					compareResult = compareLists((List)value, (List)valueCompare);
+					if(compareResult) {
+						iterator.remove();
+						break;
+					}
+
+				} else if (valueCompare instanceof Map && value instanceof Map) {
+					compareResult = compareMaps((Map)value, (Map)valueCompare);
+					if(compareResult) {
+						iterator.remove();
+						break;
+					}
+				} else if (!value.equals(valueCompare)) {
+					return false;
+				}
+			}
+
+			if(!compareResult) {
+				return false;
+			}
+
+        }
         return true;
     }
 

--- a/src/main/java/br/com/elementalsource/mock/infra/component/CompareMap.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/CompareMap.java
@@ -2,25 +2,54 @@ package br.com.elementalsource.mock.infra.component;
 
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.Multimap;
 
 @Component
 public class CompareMap {
 
-    public <K, V> Boolean isEquivalent(Map<K, V> value, Map<K, V> valueToCompare) {
-        for (Map.Entry<K, V> entrySet : value.entrySet()) {
-            final K key = entrySet.getKey();
-            if (!valueToCompare.containsKey(key)) {
-                return false;
-            }
+    public <K, V extends Comparable<V>> boolean isEquivalent(Multimap<K, V> value, Multimap<K, V> valueToCompare) {
 
-            final V valueCompare = valueToCompare.get(key);
-            if (!entrySet.getValue().equals(valueCompare)) {
-                return false;
+            for(Map.Entry<K, Collection<V>> entry : value.asMap().entrySet()){
+                final K key = entry.getKey();
+                if (!valueToCompare.containsKey(key)) {
+                    return false;
+                }
+
+                final Collection<V> valueCompare = valueToCompare.get(key);
+
+                if(!equalCollections(entry.getValue(), valueCompare)){
+                    return false;
+                }
+
             }
-        }
 
         return true;
+    }
+
+    private <V extends Comparable<V>> boolean equalCollections(Collection<V> one, Collection<V> two){
+        if (one == null && two == null){
+            return true;
+        }
+
+        if((one == null && two != null)
+                || one != null && two == null
+                || one.size() != two.size()){
+            return false;
+        }
+
+        //to avoid messing the order of the lists we will use a copy
+        List<V> first = new ArrayList<>(one);
+        List<V> second = new ArrayList<>(two);
+
+        Collections.sort(first);
+        Collections.sort(second);
+        return first.equals(second);
     }
 
 }

--- a/src/main/java/br/com/elementalsource/mock/infra/component/ExternalApi.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/ExternalApi.java
@@ -49,7 +49,7 @@ public class ExternalApi {
 
         final UriConfiguration uriConfiguration = apiProperty
                 .getConfiguration(request.getUri())
-                .orElse(new UriConfiguration(apiProperty.getHost(), Pattern.compile(".*"), state));
+                .orElse(new UriConfiguration(apiProperty.getHost(), Pattern.compile(".*"), state, ""));
         final Optional<HttpHeaders> httpHeaders = headerFilter.execute(request.getHeaders());
 
         LOGGER.info("### EXTERNAL API ###");
@@ -65,7 +65,7 @@ public class ExternalApi {
         final String parameters = request.getQuery().map(queryStringBuilder::fromMap).orElse("");
         final String url = uriConfiguration
                 .getHost()
-                .concat(request.getUri())
+                .concat(apiProperty.getRealUri(request.getUri()))
                 .concat(parameters);
 
         LOGGER.info("URL => {}", url);

--- a/src/main/java/br/com/elementalsource/mock/infra/component/QueryStringBuilder.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/QueryStringBuilder.java
@@ -1,7 +1,10 @@
 package br.com.elementalsource.mock.infra.component;
 
+import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Multimap;
+
 public interface QueryStringBuilder {
-    String fromMap(Map<String, String> queryMap);
+    String fromMap(Multimap<String, String> queryMap);
 }

--- a/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilder.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilder.java
@@ -1,10 +1,10 @@
 package br.com.elementalsource.mock.infra.component.file;
 
-import org.springframework.web.bind.annotation.RequestMethod;
+import br.com.elementalsource.mock.generic.model.Request;
 
 public interface BaseFileNameBuilder {
 
-    String buildPath(RequestMethod requestMethod, String pathUri);
+    String buildPath(Request request);
 
     String buildPath(String fileBaseName, String methodName, String pathUri);
 

--- a/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderBackup.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderBackup.java
@@ -1,5 +1,6 @@
 package br.com.elementalsource.mock.infra.component.file;
 
+import br.com.elementalsource.mock.infra.property.ApiProperty;
 import br.com.elementalsource.mock.infra.property.FileProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -9,8 +10,8 @@ import org.springframework.stereotype.Component;
 public class BaseFileNameBuilderBackup extends BaseFileNameBuilderBase implements BaseFileNameBuilder {
 
     @Autowired
-    public BaseFileNameBuilderBackup(@Qualifier("FilePropertyBackup") FileProperty fileProperty) {
-        super(fileProperty);
+    public BaseFileNameBuilderBackup(@Qualifier("FilePropertyBackup") FileProperty fileProperty, ApiProperty apiProperty) {
+        super(fileProperty, apiProperty);
     }
 
 }

--- a/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderBase.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderBase.java
@@ -1,19 +1,23 @@
 package br.com.elementalsource.mock.infra.component.file;
 
-import org.springframework.web.bind.annotation.RequestMethod;
-
+import br.com.elementalsource.mock.generic.model.Request;
+import br.com.elementalsource.mock.infra.property.ApiProperty;
 import br.com.elementalsource.mock.infra.property.FileProperty;
 
 public class BaseFileNameBuilderBase implements BaseFileNameBuilder {
 
     private final FileProperty fileProperty;
+    private final ApiProperty apiProperty;
     
-    public BaseFileNameBuilderBase(FileProperty fileProperty) {
+    public BaseFileNameBuilderBase(FileProperty fileProperty, ApiProperty apiProperty) {
         this.fileProperty = fileProperty;
+        this.apiProperty = apiProperty;
     }
 
-    public String buildPath(RequestMethod requestMethod, String pathUri) {
-        return buildPath(fileProperty.getFileBase(), requestMethod.name(), pathUri);
+    public String buildPath(Request request) {
+        String requestURI = apiProperty.getRealUri(request.getUri());
+
+        return buildPath(fileProperty.getFileBase(request), request.getMethod().name(), requestURI);
     }
 
     public String buildPath(String fileBaseName, String methodName, String pathUri) {

--- a/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderModel.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderModel.java
@@ -1,15 +1,16 @@
 package br.com.elementalsource.mock.infra.component.file;
 
+import br.com.elementalsource.mock.generic.model.Request;
 import br.com.elementalsource.mock.generic.repository.impl.ExistingFile;
 import br.com.elementalsource.mock.generic.repository.impl.ExistingFile.PathParamExtractor;
 import br.com.elementalsource.mock.generic.repository.impl.ExistingFiles;
+import br.com.elementalsource.mock.infra.property.ApiProperty;
 import br.com.elementalsource.mock.infra.property.FileProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.io.File;
 import java.util.List;
@@ -21,28 +22,26 @@ public class BaseFileNameBuilderModel extends BaseFileNameBuilderBase implements
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseFileNameBuilderModel.class);
     private ExistingFiles existingFiles;
-    private HttpServletRequest request;
+    private HttpServletRequest httpRequest;
 
     @Autowired
-    public BaseFileNameBuilderModel(@Qualifier("FilePropertyModel") FileProperty fileProperty, ExistingFiles existingFiles, HttpServletRequest request) {
-        super(fileProperty);
+    public BaseFileNameBuilderModel(@Qualifier("FilePropertyModel") FileProperty fileProperty, ExistingFiles existingFiles, HttpServletRequest httpRequest, ApiProperty apiProperty) {
+        super(fileProperty, apiProperty);
         this.existingFiles = existingFiles;
-        this.request = request;
-        final String fileBase = fileProperty.getFileBase();
-        final File file = new File(fileBase);
-        LOGGER.info("Base path to files fileBase={}, exists?{}, path={}", fileBase, file.exists(), file.getAbsoluteFile());
+        this.httpRequest = httpRequest;
     }
 
     @Override
-    public String buildPath(RequestMethod requestMethod, String pathUri) {
+    public String buildPath(Request request) {
+
         List<ExistingFile> files = existingFiles.getExistingFiles();
-        String rawPath = super.buildPath(requestMethod, pathUri);
+        String rawPath = super.buildPath(request);
 
         return files.stream()
                 .map(ef -> ef.extract(rawPath))
                 .filter(PathParamExtractor::matches)
                 .peek(pe -> {
-                   pe.getParameters().forEach(request::setAttribute);
+                   pe.getParameters().forEach(httpRequest::setAttribute);
                 })
                 .map(pe -> pe.getOriginalPath())
                 .findFirst()

--- a/src/main/java/br/com/elementalsource/mock/infra/component/gson/GsonFactory.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/gson/GsonFactory.java
@@ -1,0 +1,32 @@
+package br.com.elementalsource.mock.infra.component.gson;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.ApplicationScope;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+@Component
+public class GsonFactory {
+
+	private static Gson INSTANCE;
+
+	@Bean
+	public Gson gson(){
+		if(INSTANCE == null){
+			INSTANCE =  new GsonBuilder()
+					.enableComplexMapKeySerialization()
+					.registerTypeAdapter(Multimap.class, new MultimapAdapter())
+					.registerTypeAdapter(ArrayListMultimap.class, new MultimapAdapter())
+					.registerTypeAdapterFactory(SingleToArrayTypeAdapter.FACTORY)
+					.setPrettyPrinting()
+					.create();
+
+		}
+		return INSTANCE;
+	}
+
+}

--- a/src/main/java/br/com/elementalsource/mock/infra/component/gson/MultimapAdapter.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/gson/MultimapAdapter.java
@@ -1,0 +1,48 @@
+package br.com.elementalsource.mock.infra.component.gson;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class MultimapAdapter implements JsonSerializer<Multimap>, JsonDeserializer<Multimap> {
+	private static final Type asMapReturnType = getAsMapMethod().getGenericReturnType();
+
+	private static Type asMapType(Type multimapType) {
+		return TypeToken.of(multimapType).resolveType(asMapReturnType).getType();
+	}
+
+	private static Method getAsMapMethod() {
+		try {
+			return Multimap.class.getDeclaredMethod("asMap");
+		} catch (NoSuchMethodException e) {
+			throw new AssertionError(e);
+		}
+	}
+
+	@Override
+	public JsonElement serialize(Multimap src, Type typeOfSrc, JsonSerializationContext context) {
+		return context.serialize(src.asMap(), asMapType(typeOfSrc));
+	}
+
+	@Override
+	public Multimap deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)	throws JsonParseException {
+		Map<Object, Collection<Object>> asMap = context.deserialize(json, asMapType(typeOfT));
+		Multimap<Object, Object> listMultimap = ArrayListMultimap.create();
+		for (Map.Entry<Object, Collection<Object>> entry : asMap.entrySet()) {
+			listMultimap.putAll(entry.getKey(), entry.getValue());
+		}
+		return listMultimap;
+	}
+}

--- a/src/main/java/br/com/elementalsource/mock/infra/component/gson/SingleToArrayTypeAdapter.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/gson/SingleToArrayTypeAdapter.java
@@ -1,0 +1,59 @@
+package br.com.elementalsource.mock.infra.component.gson;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+public class SingleToArrayTypeAdapter extends TypeAdapter<List<Object>> {
+	public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+			if (!type.getRawType().isAssignableFrom(List.class)) {
+				return null;
+			}
+			Type elementType = ((ParameterizedType) type.getType()).getActualTypeArguments()[0];
+			TypeAdapter<List<Object>> delegateAdapter =
+					(TypeAdapter<List<Object>>) gson.getDelegateAdapter(this, type);
+			TypeAdapter<Object> elementAdapter =
+					(TypeAdapter<Object>) gson.getAdapter(TypeToken.get(elementType));
+			return (TypeAdapter<T>) new SingleToArrayTypeAdapter(delegateAdapter, elementAdapter);
+		}
+	};
+	final TypeAdapter<List<Object>> delegateAdapter;
+	final TypeAdapter<Object> elementAdapter;
+
+	SingleToArrayTypeAdapter(TypeAdapter<List<Object>> delegateAdapter,
+							 TypeAdapter<Object> elementAdapter) {
+		this.delegateAdapter = delegateAdapter;
+		this.elementAdapter = elementAdapter;
+	}
+
+	@Override
+	public List<Object> read(JsonReader reader) throws IOException {
+		if (reader.peek() != JsonToken.BEGIN_ARRAY) {
+			return Collections.singletonList(elementAdapter.read(reader));
+		}
+		return delegateAdapter.read(reader);
+	}
+
+	@Override
+	public void write(JsonWriter writer, List<Object> value)
+			throws IOException {
+		if (value.size() == 1) {
+			elementAdapter.write(writer, value.get(0));
+		} else {
+			delegateAdapter.write(writer, value);
+		}
+	}
+}

--- a/src/main/java/br/com/elementalsource/mock/infra/component/impl/ConvertJsonImpl.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/impl/ConvertJsonImpl.java
@@ -1,14 +1,16 @@
 package br.com.elementalsource.mock.infra.component.impl;
 
-import br.com.elementalsource.mock.infra.component.ConvertJson;
-import br.com.elementalsource.mock.infra.exception.impl.JsonApiApplicationException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.util.HashMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import br.com.elementalsource.mock.infra.component.ConvertJson;
+import br.com.elementalsource.mock.infra.exception.impl.JsonApiApplicationException;
 
 @Component
 public class ConvertJsonImpl implements ConvertJson {

--- a/src/main/java/br/com/elementalsource/mock/infra/component/impl/QueryStringBuilderImpl.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/component/impl/QueryStringBuilderImpl.java
@@ -5,7 +5,13 @@ import br.com.elementalsource.mock.infra.component.QueryStringBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Multimap;
 
 @Component
 public class QueryStringBuilderImpl implements QueryStringBuilder {
@@ -18,14 +24,13 @@ public class QueryStringBuilderImpl implements QueryStringBuilder {
     }
 
     @Override
-    public String fromMap(Map<String, String> queryMap) {
-        return queryMap
-                .entrySet()
-                .stream()
-                .map(entry -> "&".concat(entry.getKey()).concat("=").concat(entry.getValue()))
-                .reduce(String::concat)
-                .map(s -> "?" + s.substring(1, s.length()))
-                .orElse("");
+    public String fromMap(Multimap<String, String> queryMap) {
+
+        String queryString = queryMap.asMap().entrySet().stream().map(e -> {
+            return e.getValue().stream().map(v -> e.getKey() + "=" + v).collect(Collectors.joining("&"));
+        }).collect(Collectors.joining("&", "?", ""));
+
+        return queryString.length() > 1 ? queryString : "";
     }
 
 }

--- a/src/main/java/br/com/elementalsource/mock/infra/exception/ApplicationExceptionHandler.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/exception/ApplicationExceptionHandler.java
@@ -7,6 +7,7 @@ import br.com.elementalsource.mock.infra.exception.impl.ErrorApplicationExceptio
 import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -19,7 +20,9 @@ import org.springframework.web.client.ResourceAccessException;
 public class ApplicationExceptionHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationExceptionHandler.class);
-    private static final Gson GSON = new Gson();
+
+    @Autowired
+    private Gson gson;
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ApplicationExceptionImpl.class)
@@ -58,7 +61,7 @@ public class ApplicationExceptionHandler {
     @ExceptionHandler(HttpClientErrorException.class)
     @ResponseBody
     public ApplicationExceptionMessage handleHttpClientErrorException(HttpClientErrorException e) {
-        final ApplicationExceptionMessageImpl applicationExceptionMessage = GSON.fromJson(e.getResponseBodyAsString(), ApplicationExceptionMessageImpl.class);
+        final ApplicationExceptionMessageImpl applicationExceptionMessage = gson.fromJson(e.getResponseBodyAsString(), ApplicationExceptionMessageImpl.class);
         LOGGER.error("handleHttpClientErrorException", e);
         return applicationExceptionMessage;
     }

--- a/src/main/java/br/com/elementalsource/mock/infra/model/UriConfiguration.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/model/UriConfiguration.java
@@ -10,11 +10,13 @@ public class UriConfiguration implements Serializable {
     private String host;
     private Pattern pattern;
     private Boolean backup;
+    private String prefixPath;
 
-    public UriConfiguration(String host, Pattern pattern, Boolean backup) {
+    public UriConfiguration(String host, Pattern pattern, Boolean backup, String prefixPath) {
         this.host = host;
         this.pattern = pattern;
         this.backup = backup;
+        this.prefixPath = prefixPath;
     }
 
     public UriConfiguration() {
@@ -31,6 +33,14 @@ public class UriConfiguration implements Serializable {
 
     public Pattern getPattern() {
         return pattern;
+    }
+
+	public void setPrefixPath(final String prefixPath) {
+		this.prefixPath = prefixPath;
+	}
+
+	public String getPrefixPath() {
+        return prefixPath;
     }
 
     public void setPattern(String pattern) {

--- a/src/main/java/br/com/elementalsource/mock/infra/property/ApiProperty.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/property/ApiProperty.java
@@ -49,6 +49,10 @@ public class ApiProperty {
                 .filter(config -> config.getPattern().matcher(uri).find()).findAny();
     }
 
+    public String getRealUri(String uri){
+       return getConfiguration(uri).map(config -> uri.replaceAll(config.getPattern().pattern(), "")).orElse(uri);
+    }
+
     public String getHost() {
         return host;
     }

--- a/src/main/java/br/com/elementalsource/mock/infra/property/FileProperty.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/property/FileProperty.java
@@ -1,7 +1,11 @@
 package br.com.elementalsource.mock.infra.property;
 
+import br.com.elementalsource.mock.generic.model.Request;
+
 public interface FileProperty {
 
-    String getFileBase();
+    String getFileBase(Request request);
+
+    String getRootPath();
 
 }

--- a/src/main/java/br/com/elementalsource/mock/infra/property/impl/FilePropertyBackup.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/property/impl/FilePropertyBackup.java
@@ -1,6 +1,15 @@
 package br.com.elementalsource.mock.infra.property.impl;
 
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import br.com.elementalsource.mock.generic.model.Request;
+import br.com.elementalsource.mock.infra.model.UriConfiguration;
+import br.com.elementalsource.mock.infra.property.ApiProperty;
 import br.com.elementalsource.mock.infra.property.FileProperty;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -8,12 +17,22 @@ import org.springframework.stereotype.Component;
 public class FilePropertyBackup implements FileProperty {
 
     private final String fileBase;
+    private final ApiProperty apiProperty;
 
-    public FilePropertyBackup(@Value("${file.backup.path}") String fileBase) {
+    @Autowired
+    public FilePropertyBackup(@Value("${file.backup.path}") String fileBase, ApiProperty apiProperty) {
         this.fileBase = fileBase;
+        this.apiProperty = apiProperty;
     }
 
-    public String getFileBase() {
+    public String getFileBase(Request request) {
+        String uri = request.getUri();
+        String prefix = apiProperty.getConfiguration(uri).map(config -> config.getPrefixPath()).orElse("");
+        return Paths.get(fileBase, prefix).toString();
+    }
+
+    @Override
+    public String getRootPath() {
         return fileBase;
     }
 

--- a/src/main/java/br/com/elementalsource/mock/infra/property/impl/FilePropertyModel.java
+++ b/src/main/java/br/com/elementalsource/mock/infra/property/impl/FilePropertyModel.java
@@ -1,6 +1,14 @@
 package br.com.elementalsource.mock.infra.property.impl;
 
+import java.nio.file.Paths;
+import java.util.List;
+
+import br.com.elementalsource.mock.generic.model.Request;
+import br.com.elementalsource.mock.infra.model.UriConfiguration;
+import br.com.elementalsource.mock.infra.property.ApiProperty;
 import br.com.elementalsource.mock.infra.property.FileProperty;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -8,12 +16,22 @@ import org.springframework.stereotype.Component;
 public class FilePropertyModel implements FileProperty {
 
     private final String fileBase;
+    private final ApiProperty apiProperty;
 
-    public FilePropertyModel(@Value("${file.base}") String fileBase) {
+    @Autowired
+    public FilePropertyModel(@Value("${file.base}") String fileBase, ApiProperty apiProperty) {
         this.fileBase = fileBase;
+        this.apiProperty = apiProperty;
     }
 
-    public String getFileBase() {
+    public String getFileBase(Request request) {
+        String uri = request.getUri();
+        String prefix = apiProperty.getConfiguration(uri).map(config -> config.getPrefixPath()).orElse("");
+        return Paths.get(fileBase, prefix).toString();
+    }
+
+    @Override
+    public String getRootPath() {
         return fileBase;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ api:
   # When is not find in repository, then will try to do a request in this host
   host: "http://www.mocky.io"
 
-  magicalHeaders: "Accept,User-Agent,Content-Type"
+  acceptedHeaders: "Accept,User-Agent,Content-Type"
 
   # Default headers to do a request
   defaultHeaders:
@@ -28,12 +28,13 @@ api:
   # When a request uri match with some pattern, than this host will be used
   uriConfigurations:
     -
-      host: "http://www.mocky2.io"
-      pattern: "begin-of-uri/|another-pattern/"
-      backup: false
+      host: "http://some-site1.com"
+      pattern: "/site1"
+      prefixPath: "site1"
     -
-      host: "http://www.mocky3.io"
-      pattern: "teste/|test/"
+      host: "http://some-site2.com"
+      pattern: "/site2"
+      prefixPath: "site2"
 
 # Paths of json
 file:

--- a/src/test/java/br/com/elementalsource/mock/configuration/api/v1/controller/CaptureStateControllerIntegrationTest.java
+++ b/src/test/java/br/com/elementalsource/mock/configuration/api/v1/controller/CaptureStateControllerIntegrationTest.java
@@ -27,6 +27,8 @@ public class CaptureStateControllerIntegrationTest {
 
     @Autowired
     private MockMvc mvc;
+    @Autowired
+    private Gson gson;
 
     @MockBean
     private CaptureStateService captureStateService;
@@ -63,7 +65,7 @@ public class CaptureStateControllerIntegrationTest {
     public void shouldBeEnableCaptureMode() throws Exception {
         // given
         final CaptureState captureState = new CaptureState(true);
-        final String requestBody = new Gson().toJson(new CaptureStateDto(captureState));
+        final String requestBody = gson.toJson(new CaptureStateDto(captureState));
 
         given(captureStateService.enable())
                 .willReturn(captureState);

--- a/src/test/java/br/com/elementalsource/mock/generic/api/v1/controller/GenericApiControllerExternalIntegrationTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/api/v1/controller/GenericApiControllerExternalIntegrationTest.java
@@ -33,6 +33,8 @@ public class GenericApiControllerExternalIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
+    @Autowired
+    private Gson gson;
 
     @Value("${file.base}")
     private String fileBase;
@@ -82,9 +84,9 @@ public class GenericApiControllerExternalIntegrationTest {
                 Paths.get(resource.getAbsolutePath(), httpMethod.name().toLowerCase(), url, "1" + fileExtension)
                         .toAbsolutePath().toString();
 
-        final EndpointDto endpointDto = new Gson().fromJson(getJson(fileName), EndpointDto.class);
-        final String requestJson = new Gson().toJson(endpointDto.getRequest().getBody());
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final EndpointDto endpointDto = gson.fromJson(getJson(fileName), EndpointDto.class);
+        final String requestJson = gson.toJson(endpointDto.getRequest().getBody());
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
 
         final HttpHeaders httpHeaders = headers.filter(mapHeaders -> !mapHeaders.isEmpty()).map(map -> {
             final HttpHeaders result = new HttpHeaders();

--- a/src/test/java/br/com/elementalsource/mock/generic/api/v1/controller/GenericApiControllerIntegrationTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/api/v1/controller/GenericApiControllerIntegrationTest.java
@@ -24,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -37,6 +39,8 @@ public class GenericApiControllerIntegrationTest {
 
     @Autowired
     private QueryStringBuilder queryStringBuilder;
+    @Autowired
+    private Gson gson;
 
     @Value("${file.extension}")
     private String fileExtension;
@@ -68,7 +72,7 @@ public class GenericApiControllerIntegrationTest {
 
         final String endpointJson = getJson(fileName);
 
-        final EndpointDto endpointDto = new Gson().fromJson(endpointJson, EndpointDto.class);
+        final EndpointDto endpointDto = gson.fromJson(endpointJson, EndpointDto.class);
         final Endpoint endpoint = endpointDto.toModel(RequestMethod.GET, uri);
         final String parameters = endpoint
                 .getRequest()
@@ -78,7 +82,7 @@ public class GenericApiControllerIntegrationTest {
                 .map(""::concat)
                 .orElse("");
 
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
 
         // when
         final ResponseEntity<String> response = restTemplate.getForEntity(uri.concat(parameters), String.class);
@@ -96,8 +100,8 @@ public class GenericApiControllerIntegrationTest {
                 Paths.get(resource.getAbsolutePath(), "get", uri, "1" + fileExtension)
                         .toAbsolutePath().toString();
         final String endpointJson = getJson(fileName);
-        final EndpointDto endpointDto = new Gson().fromJson(endpointJson, EndpointDto.class);
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final EndpointDto endpointDto = gson.fromJson(endpointJson, EndpointDto.class);
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
 
         // when
         final ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
@@ -116,8 +120,8 @@ public class GenericApiControllerIntegrationTest {
                 Paths.get(resource.getAbsolutePath(), "get", uri, "1" + fileExtension)
                         .toAbsolutePath().toString();
         final String endpointJson = getJson(fileName);
-        final EndpointDto endpointDto = new Gson().fromJson(endpointJson, EndpointDto.class);
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final EndpointDto endpointDto = gson.fromJson(endpointJson, EndpointDto.class);
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
 
         // when
         final ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
@@ -136,8 +140,8 @@ public class GenericApiControllerIntegrationTest {
         final String fileName =
                 Paths.get(resource.getAbsolutePath(), "get", uri, "1" + fileExtension)
                         .toAbsolutePath().toString();
-        final EndpointDto endpointDto = new Gson().fromJson(getJson(fileName), EndpointDto.class);
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final EndpointDto endpointDto = gson.fromJson(getJson(fileName), EndpointDto.class);
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
 
         // when
         final ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
@@ -155,8 +159,8 @@ public class GenericApiControllerIntegrationTest {
         final String fileName =
                 Paths.get(resource.getAbsolutePath(), "get", uri, "2" + fileExtension)
                         .toAbsolutePath().toString();
-        final EndpointDto endpointDto = new Gson().fromJson(getJson(fileName), EndpointDto.class);
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final EndpointDto endpointDto = gson.fromJson(getJson(fileName), EndpointDto.class);
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
         final String query = queryStringBuilder.fromMap(endpointDto.getRequest().getQuery());
 
         // when
@@ -198,9 +202,9 @@ public class GenericApiControllerIntegrationTest {
                 Paths.get(resource.getAbsolutePath(), httpMethod.name().toLowerCase(), uri, caseX + fileExtension)
                         .toAbsolutePath().toString();
 
-        final EndpointDto endpointDto = new Gson().fromJson(getJson(fileName), EndpointDto.class);
-        final String requestJson = new Gson().toJson(endpointDto.getRequest().getBody());
-        final String responseJson = new Gson().toJson(endpointDto.getResponse().getBody());
+        final EndpointDto endpointDto = gson.fromJson(getJson(fileName), EndpointDto.class);
+        final String requestJson = gson.toJson(endpointDto.getRequest().getBody());
+        final String responseJson = gson.toJson(endpointDto.getResponse().getBody());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/test/java/br/com/elementalsource/mock/generic/api/v1/mapper/RequestMapperTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/api/v1/mapper/RequestMapperTest.java
@@ -4,7 +4,11 @@ import br.com.elementalsource.mock.generic.mapper.QueryDecoder;
 import br.com.elementalsource.mock.generic.model.Request;
 import br.com.elementalsource.mock.generic.mapper.HeaderMapper;
 import br.com.elementalsource.mock.generic.mapper.QueryMapper;
+import br.com.elementalsource.mock.infra.component.gson.GsonFactory;
+
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,12 +32,14 @@ public class RequestMapperTest {
 
     private QueryMapper queryMapper;
     private HeaderMapper headerMapper;
+    private Gson gson;
 
     @Before
     public void init() {
         this.queryMapper = new QueryMapper(new QueryDecoder().decoderFactoryImplementation(""));
         this.headerMapper = new HeaderMapper();
-        this.requestMapper = new RequestMapper(queryMapper, headerMapper);
+        this.gson = new GsonFactory().gson();
+        this.requestMapper = new RequestMapper(queryMapper, headerMapper,gson);
     }
 
     @Test

--- a/src/test/java/br/com/elementalsource/mock/generic/mapper/EndpointDtoTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/mapper/EndpointDtoTest.java
@@ -1,6 +1,7 @@
 package br.com.elementalsource.mock.generic.mapper;
 
 import br.com.elementalsource.mock.generic.model.Endpoint;
+import br.com.elementalsource.mock.infra.component.gson.GsonFactory;
 import br.com.elementalsource.mock.infra.component.impl.FromJsonStringToObjectConverterImpl;
 import br.com.elementalsource.mock.generic.model.template.EndpointTemplate;
 import br.com.six2six.fixturefactory.Fixture;
@@ -16,6 +17,8 @@ import static org.junit.Assert.*;
 
 public class EndpointDtoTest {
 
+    private static Gson gson = new GsonFactory().gson();
+
     @BeforeClass
     public static void initClass() {
         FixtureFactoryLoader.loadTemplates("br.com.elementalsource.mock.generic.model.template");
@@ -27,7 +30,7 @@ public class EndpointDtoTest {
         final String json = "{\"request\":{\"body\":[{\"run\":\"7\"}]},\"response\":{\"body\":[{\"age\":8}]}}";
 
         // when
-        final EndpointDto endpointDto = new Gson().fromJson(json, EndpointDto.class);
+        final EndpointDto endpointDto = gson.fromJson(json, EndpointDto.class);
         final Endpoint endpoint = endpointDto.toModel(RequestMethod.GET, "/product");
 
         // then
@@ -44,7 +47,7 @@ public class EndpointDtoTest {
         final String json = "{\"request\":{\"body\":[{\"run\":\"7\"}]},\"response\":{\"body\":[{\"age\":8}]}}";
 
         // when
-        final EndpointDto endpointDto = new Gson().fromJson(json, EndpointDto.class);
+        final EndpointDto endpointDto = gson.fromJson(json, EndpointDto.class);
         final Endpoint endpoint = endpointDto.toModel(RequestMethod.GET, "/product");
 
         // then
@@ -82,7 +85,7 @@ public class EndpointDtoTest {
 
         // when
         final EndpointDto endpointDto = new EndpointDto(endpoint, new FromJsonStringToObjectConverterImpl());
-        final String json = new Gson().toJson(endpointDto);
+        final String json = gson.toJson(endpointDto);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);
@@ -114,7 +117,7 @@ public class EndpointDtoTest {
 
         // when
         final EndpointDto endpointDto = new EndpointDto(endpoint, new FromJsonStringToObjectConverterImpl());
-        final String json = new Gson().toJson(endpointDto);
+        final String json = gson.toJson(endpointDto);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);
@@ -154,7 +157,7 @@ public class EndpointDtoTest {
 
         // when
         final EndpointDto endpointDto = new EndpointDto(endpoint, new FromJsonStringToObjectConverterImpl());
-        final String json = new Gson().toJson(endpointDto);
+        final String json = gson.toJson(endpointDto);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);

--- a/src/test/java/br/com/elementalsource/mock/generic/mapper/QueryMapperTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/mapper/QueryMapperTest.java
@@ -1,12 +1,15 @@
 package br.com.elementalsource.mock.generic.mapper;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,7 +31,7 @@ public class QueryMapperTest {
         final String queryRequest = null;
 
         // when
-        final Optional<Map<String, String>> result = queryMapper.mapper(queryRequest);
+        final Optional<Multimap<String, String>> result = queryMapper.mapper(queryRequest);
 
         // then
         assertFalse(result.isPresent());
@@ -40,7 +43,7 @@ public class QueryMapperTest {
         final String queryRequest = "";
 
         // when
-        final Optional<Map<String, String>> result = queryMapper.mapper(queryRequest);
+        final Optional<Multimap<String, String>> result = queryMapper.mapper(queryRequest);
 
         // then
         assertFalse(result.isPresent());
@@ -55,7 +58,7 @@ public class QueryMapperTest {
                 .build();
 
         // when
-        final Optional<Map<String, String>> result = queryMapper.mapper(queryRequest);
+        final Optional<Multimap<String, String>> result = queryMapper.mapper(queryRequest);
 
         // then
         assertTrue(result.isPresent());
@@ -72,7 +75,7 @@ public class QueryMapperTest {
                 .build();
 
         // when
-        final Optional<Map<String, String>> result = queryMapper.mapper(queryRequest);
+        final Optional<Multimap<String, String>> result = queryMapper.mapper(queryRequest);
 
         // then
         assertTrue(result.isPresent());

--- a/src/test/java/br/com/elementalsource/mock/generic/mapper/ResponseDtoTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/mapper/ResponseDtoTest.java
@@ -1,6 +1,7 @@
 package br.com.elementalsource.mock.generic.mapper;
 
 import br.com.elementalsource.mock.generic.model.template.ResponseTemplate;
+import br.com.elementalsource.mock.infra.component.gson.GsonFactory;
 import br.com.elementalsource.mock.infra.component.impl.FromJsonStringToObjectConverterImpl;
 import br.com.elementalsource.mock.generic.model.Response;
 import br.com.six2six.fixturefactory.Fixture;
@@ -16,6 +17,8 @@ import static org.junit.Assert.assertNotNull;
 
 public class ResponseDtoTest {
 
+    private static Gson gson = new GsonFactory().gson();
+
     @BeforeClass
     public static void initClass() {
         FixtureFactoryLoader.loadTemplates("br.com.elementalsource.mock.generic.model.template");
@@ -27,7 +30,7 @@ public class ResponseDtoTest {
         final String json = "{ \"body\": { \"tt\": \"789\" } }";
 
         // when
-        final ResponseDto responseDto = new Gson().fromJson(json, ResponseDto.class);
+        final ResponseDto responseDto = gson.fromJson(json, ResponseDto.class);
         final Response response = responseDto.toModel();
 
         // then
@@ -42,7 +45,7 @@ public class ResponseDtoTest {
         final String json = "{ \"body\": [{ \"age\": 10 }, { \"age\": 11 }] }";
 
         // when
-        final ResponseDto responseDto = new Gson().fromJson(json, ResponseDto.class);
+        final ResponseDto responseDto = gson.fromJson(json, ResponseDto.class);
         final Response response = responseDto.toModel();
 
         // then
@@ -59,7 +62,7 @@ public class ResponseDtoTest {
 
         // when
         final ResponseDto modelDto = new ResponseDto(model, new FromJsonStringToObjectConverterImpl());
-        final String json = new Gson().toJson(modelDto);
+        final String json = gson.toJson(modelDto);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);
@@ -73,7 +76,7 @@ public class ResponseDtoTest {
 
         // when
         final ResponseDto modelDto = new ResponseDto(model, new FromJsonStringToObjectConverterImpl());
-        final String json = new Gson().toJson(modelDto);
+        final String json = gson.toJson(modelDto);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);

--- a/src/test/java/br/com/elementalsource/mock/generic/repository/impl/EndpointRepositoryModelTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/repository/impl/EndpointRepositoryModelTest.java
@@ -36,11 +36,10 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class EndpointRepositoryModelTest {
 
-    private static final String NAME = "/get/";
     @InjectMocks
     private EndpointRepositoryModel endpointRepositoryModel;
     @Mock
-    private FileProperty fileProperty;
+    private Request request;
     @Mock
     private FileExtensionProperty fileExtensionProperty;
     @Mock
@@ -83,9 +82,9 @@ public class EndpointRepositoryModelTest {
         // when
         when(endpointMapper.mapper(any(), any(), any())).thenReturn(endpoint);
         when(fileExtensionProperty.getFileExtension()).thenReturn(fileExtension);
-        when(baseFileNameBuilder.buildPath(any(), any())).thenReturn(basePath);
+        when(baseFileNameBuilder.buildPath(any())).thenReturn(basePath);
 
-        final Collection<Endpoint> mocks = endpointRepositoryModel.getByMethodAndUri(requestMethod, requestUrl);
+        final Collection<Endpoint> mocks = endpointRepositoryModel.getAllByRequest(request);
 
         // then
         assertNotNull(mocks);
@@ -100,9 +99,9 @@ public class EndpointRepositoryModelTest {
         final String basePath = Paths.get(resource.getAbsolutePath(), requestUrl).toAbsolutePath().toString();
 
         // when
-        when(baseFileNameBuilder.buildPath(any(), any())).thenReturn(basePath);
+        when(baseFileNameBuilder.buildPath(any())).thenReturn(basePath);
 
-        final Collection<Endpoint> mocks = endpointRepositoryModel.getByMethodAndUri(requestMethod, requestUrl);
+        final Collection<Endpoint> mocks = endpointRepositoryModel.getAllByRequest(request);
 
         // then
         assertNotNull(mocks);
@@ -119,10 +118,10 @@ public class EndpointRepositoryModelTest {
         // when
         when(endpointMapper.mapper(any(), any(), any())).thenReturn(result);
         when(fileExtensionProperty.getFileExtension()).thenReturn(fileExtension);
-        when(baseFileNameBuilder.buildPath(any(), any())).thenReturn(basePath);
+        when(baseFileNameBuilder.buildPath(any())).thenReturn(basePath);
         when(endpointMockFileFilterRequest.apply(any(), any())).thenReturn(true);
 
-        final Optional<Endpoint> endpointMock = endpointRepositoryModel.getByMethodAndRequest(mock(Request.class));
+        final Optional<Endpoint> endpointMock = endpointRepositoryModel.getByRequest(mock(Request.class));
 
         // then
         assertEquals(result, endpointMock);

--- a/src/test/java/br/com/elementalsource/mock/generic/service/impl/EndpointBackupServiceFileIntegrarionTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/service/impl/EndpointBackupServiceFileIntegrarionTest.java
@@ -67,11 +67,10 @@ public class EndpointBackupServiceFileIntegrarionTest {
         responseJson = endpoint.getResponse().getBody();
 
         uri = endpoint.getRequest().getUri();
-        String backupPathName = new File("").getAbsolutePath() + "/" + fileProperty.getFileBase();
+        String backupPathName = new File("").getAbsolutePath() + "/" + fileProperty.getRootPath();
         this.baseName = backupPathName + "/";
         fileName = baseName + endpoint.getRequest().getMethod().name().toLowerCase() + uri + "/1" + fileExtensionProperty.getFileExtension();
 
-        deleteBackupFolder();
         this.resource = getClass().getClassLoader().getResource(fileBase);
     }
 
@@ -81,14 +80,9 @@ public class EndpointBackupServiceFileIntegrarionTest {
         assertNotNull(resource.getFile());
     }
 
-    public void deleteBackupFolder() throws IOException {
-        endpointBackupService.cleanAllBackupData();
-    }
-
     @After
     public void setupRestore() throws IOException {
         restTemplate.delete(CONFIGURATION_CAPTURE_STATE + "/disable"); // change setup
-        deleteBackupFolder();
     }
 
     @Test(timeout = 2000)

--- a/src/test/java/br/com/elementalsource/mock/generic/service/impl/EndpointBackupServiceFileTest.java
+++ b/src/test/java/br/com/elementalsource/mock/generic/service/impl/EndpointBackupServiceFileTest.java
@@ -50,12 +50,12 @@ public class EndpointBackupServiceFileTest {
     private BaseFileNameBuilderModel baseFileNameBuilder;
     @Mock
     private FileNameGenerator fileNameGenerator;
-    @Mock(answer = Answers.CALLS_REAL_METHODS)
-    private FromJsonStringToObjectConverter fromJsonStringToObjectConverter;
-    @Mock(answer = Answers.CALLS_REAL_METHODS)
-    private JsonFormatterPretty jsonFormatterPretty;
     @Mock
     private EndpointRepository endpointRepository;
+    @Mock
+    private FromJsonStringToObjectConverter fromJsonStringToObjectConverter;
+    @Mock
+    private JsonFormatterPretty jsonFormatterPretty;
 
     @BeforeClass
     public static void initClass() {
@@ -73,11 +73,11 @@ public class EndpointBackupServiceFileTest {
 
         // when
         if (Files.exists(path)) Files.delete(path);
-        when(endpointRepository.getByMethodAndRequest(any(Request.class))).thenReturn(Optional.empty());
+        when(endpointRepository.getByRequest(any(Request.class))).thenReturn(Optional.empty());
         when(baseFileNameBuilder.buildPath(anyString(), anyString(), anyString())).thenReturn(pathName);
         when(fileExtensionProperty.getFileExtension()).thenReturn(fileExtension);
         when(fileNameGenerator.fromPath(anyString())).thenReturn(fileName);
-        when(fileProperty.getFileBase()).thenReturn(BACKUP_TEMP);
+        when(fileProperty.getFileBase(any())).thenReturn(BACKUP_TEMP);
 
         endpointBackupServiceFile.doBackup(endpoint);
 
@@ -85,43 +85,5 @@ public class EndpointBackupServiceFileTest {
         assertTrue(Files.exists(path));
     }
 
-    @Test
-    @Ignore
-    public void shouldRemoveEverithingImportantInsidePath() throws IOException {
-        // given
-        final String baseNameFilesToRemove = BACKUP_TEMP + "data/files";
-        final Path pathsToRemove = Paths.get(baseNameFilesToRemove + "/file1.json");
-
-        final String baseNameFilesToNotRemove = BACKUP_TEMP + ".keep-folder";
-        final Path pathsDoNotRemove = Paths.get(baseNameFilesToNotRemove + "/fileDotNotRemove1.json");
-
-        final Path keepFilePath = Paths.get(baseNameFilesToNotRemove + ".keep-file");
-
-        // before
-        if (Files.exists(pathsToRemove)) Files.delete(pathsToRemove);
-        if (Files.exists(pathsDoNotRemove)) Files.delete(pathsDoNotRemove);
-        Files.deleteIfExists(keepFilePath);
-
-        // when
-        when(fileProperty.getFileBase()).thenReturn(BACKUP_TEMP);
-
-        Files.createDirectories(Paths.get(baseNameFilesToRemove));
-        Files.createFile(pathsToRemove);
-
-        Files.createDirectories(Paths.get(baseNameFilesToNotRemove));
-        Files.createFile(pathsDoNotRemove);
-
-        assertTrue(Files.exists(pathsToRemove));
-        assertTrue(Files.exists(pathsDoNotRemove));
-
-        endpointBackupServiceFile.cleanAllBackupData();
-
-        // then
-        assertFalse(Files.exists(pathsToRemove));
-        assertTrue(Files.exists(pathsDoNotRemove));
-
-        // after
-        FileSystemUtils.deleteRecursively(new File(baseNameFilesToNotRemove)); // dangerous
-    }
 
 }

--- a/src/test/java/br/com/elementalsource/mock/infra/component/ApiPropertyTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/ApiPropertyTest.java
@@ -50,7 +50,7 @@ public class ApiPropertyTest {
     @Test
     public void shouldLoadUriConfigurations() {
         // given
-        final UriConfiguration uriConfiguration = new UriConfiguration("http://www.mocky.io", Pattern.compile("/v2/57fbd6280f0000ed154fd470", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE), false);
+        final UriConfiguration uriConfiguration = new UriConfiguration("http://www.mocky.io", Pattern.compile("/v2/57fbd6280f0000ed154fd470", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE), false, "");
 
         // when
         final List<UriConfiguration> uriConfigurations = apiProperty.getUriConfigurations();

--- a/src/test/java/br/com/elementalsource/mock/infra/component/CompareJsonTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/CompareJsonTest.java
@@ -37,6 +37,59 @@ public class CompareJsonTest {
     }
 
     @Test
+    public void shouldBeEquivalentWhenIsEqualButInDifferentOrder() throws IOException {
+        // given
+        final String jsonKey = "{\"id\": 10, \"name\":\"banana\"}";
+        final String jsonToCompare = "{\"name\":\"banana\", \"id\": 10}";
+
+        // when
+        final Boolean equivalent = compareJson.isEquivalent(jsonKey, jsonToCompare);
+
+        // then
+        assertTrue(equivalent);
+    }
+
+    @Test
+    public void shouldBeEquivalentWhenIsEqualButAnElementIsAList() throws IOException {
+        // given
+        final String jsonKey = "{\"id\": 10, \"values\": [{\"b\":2, \"a\":1}]}";
+        final String jsonToCompare = "{\"id\": 10, \"values\": [{\"a\":1, \"b\":2}]}";
+
+        // when
+        final Boolean equivalent = compareJson.isEquivalent(jsonKey, jsonToCompare);
+
+        // then
+        assertTrue(equivalent);
+    }
+
+    @Test
+    public void shouldBeDifferentWhenIsEqualButSecondListHasFewerElements() throws IOException {
+        // given
+        final String jsonKey = "{\"id\": 10, \"values\": [{\"b\":2, \"a\":1}, {\"b\":2, \"a\":1}]}";
+        final String jsonToCompare = "{\"id\": 10, \"values\": [{\"a\":1, \"b\":2}]}";
+
+        // when
+        final Boolean equivalent = compareJson.isEquivalent(jsonKey, jsonToCompare);
+
+        // then
+        assertFalse(equivalent);
+    }
+
+    @Test
+    public void shouldBeEquivalentWhenIsEqualButAnElementIsAListOfMaps() throws IOException {
+        // given
+        final String jsonKey = "{\"id\": 10, \"values\": [{\"a\":1, \"b\":2},{\"c\":3, \"d\":3}]}";
+        final String jsonToCompare = "{\"id\": 10, \"values\": [{\"d\":3, \"c\":3},{\"a\":1, \"b\":2}]}";
+
+        // when
+        final Boolean equivalent = compareJson.isEquivalent(jsonKey, jsonToCompare);
+
+        // then
+        assertTrue(equivalent);
+    }
+
+
+    @Test
     public void shouldBeEquivalentWhenExistsFieldsIgnoreds() throws IOException {
         // given
         final String jsonKey = "{\"id\": 10}";

--- a/src/test/java/br/com/elementalsource/mock/infra/component/CompareMapTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/CompareMapTest.java
@@ -1,6 +1,9 @@
 package br.com.elementalsource.mock.infra.component;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -18,10 +21,10 @@ public class CompareMapTest {
     @Test
     public void shouldBeEqualsWhenCompareValueMaps() {
         // given
-        final ImmutableMap<String, String> map = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> map = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .build();
-        final ImmutableMap<String, String> mapToCompare = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> mapToCompare = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .build();
 
@@ -35,10 +38,10 @@ public class CompareMapTest {
     @Test
     public void shouldBeEqualsWhenCompareValueMapsWhereHaveMoreAttributesInComparation() {
         // given
-        final ImmutableMap<String, String> map = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> map = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .build();
-        final ImmutableMap<String, String> mapToCompare = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> mapToCompare = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .put("age", "15")
                 .build();
@@ -53,11 +56,11 @@ public class CompareMapTest {
     @Test
     public void shouldNotBeEqualsWhenCompareValueMapsWhereHaveLessAttributesInComparation() {
         // given
-        final ImmutableMap<String, String> map = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> map = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .put("age", "15")
                 .build();
-        final ImmutableMap<String, String> mapToCompare = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> mapToCompare = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .build();
 
@@ -71,11 +74,11 @@ public class CompareMapTest {
     @Test
     public void shouldNotBeEqualsWhenThereDifferentValues() {
         // given
-        final ImmutableMap<String, String> map = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> map = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .put("age", "15")
                 .build();
-        final ImmutableMap<String, String> mapToCompare = ImmutableMap.<String, String>builder()
+        final Multimap<String, String> mapToCompare = ImmutableMultimap.<String,String>builder()
                 .put("name", "Paul")
                 .put("age", "25")
                 .build();

--- a/src/test/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderModelTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/file/BaseFileNameBuilderModelTest.java
@@ -1,10 +1,12 @@
 package br.com.elementalsource.mock.infra.component.file;
 
+import br.com.elementalsource.mock.generic.model.Request;
 import br.com.elementalsource.mock.infra.property.FileProperty;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,32 +31,34 @@ public class BaseFileNameBuilderModelTest {
     @Qualifier("BaseFileNameBuilderModel")
     private BaseFileNameBuilder baseFileNameBuilder;
 
+    private Request request;
+
     @Before
     public void init() {
-        this.resource = getClass().getClassLoader().getResource(fileProperty.getFileBase());
+        request = Mockito.mock(Request.class);
+        Mockito.when(request.getMethod()).thenReturn(RequestMethod.GET);
+        Mockito.when(request.getUri()).thenReturn("/person");
+
+        this.resource = getClass().getClassLoader().getResource(fileProperty.getRootPath());
     }
 
     @Test
     public void shouldHavePathToTest() {
         assertNotNull(baseFileNameBuilder);
-        assertNotNull(fileProperty.getFileBase());
-        assertFalse(fileProperty.getFileBase().isEmpty());
+        assertNotNull(fileProperty.getFileBase(request));
+        assertFalse(fileProperty.getFileBase(request).isEmpty());
         assertNotNull(resource);
         assertNotNull(resource.getFile());
     }
 
     @Test
     public void shouldBuildPath() {
-        // given
-        final RequestMethod requestMethod = RequestMethod.GET;
-        final String pathUri = "/person";
-
         // when
-        final String path = baseFileNameBuilder.buildPath(requestMethod, pathUri);
+        final String path = baseFileNameBuilder.buildPath(request);
 
         // then
         assertNotNull(path);
-        assertThat(path, CoreMatchers.endsWith(fileProperty.getFileBase() + "/get/person"));
+        assertThat(path, CoreMatchers.endsWith(fileProperty.getFileBase(request) + "/get/person"));
     }
 
 }

--- a/src/test/java/br/com/elementalsource/mock/infra/component/impl/FromJsonStringToObjectConverterImplTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/impl/FromJsonStringToObjectConverterImplTest.java
@@ -11,8 +11,12 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Optional;
 
+import br.com.elementalsource.mock.infra.component.gson.GsonFactory;
+
 @RunWith(MockitoJUnitRunner.class)
 public class FromJsonStringToObjectConverterImplTest {
+
+    private static Gson gson = new GsonFactory().gson();
 
     @InjectMocks
     private FromJsonStringToObjectConverterImpl converter;
@@ -25,7 +29,7 @@ public class FromJsonStringToObjectConverterImplTest {
 
         // when
         final Object jsonObject = converter.apply(jsonString);
-        final String json = new Gson().toJson(jsonObject);
+        final String json = gson.toJson(jsonObject);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);
@@ -39,7 +43,7 @@ public class FromJsonStringToObjectConverterImplTest {
 
         // when
         final Object jsonObject = converter.apply(jsonString);
-        final String json = new Gson().toJson(jsonObject);
+        final String json = gson.toJson(jsonObject);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);
@@ -53,7 +57,7 @@ public class FromJsonStringToObjectConverterImplTest {
 
         // when
         final Object jsonObject = converter.apply(jsonString);
-        final String json = new Gson().toJson(jsonObject);
+        final String json = gson.toJson(jsonObject);
 
         // then
         JSONAssert.assertEquals(expectedJson, json, false);

--- a/src/test/java/br/com/elementalsource/mock/infra/component/impl/QueryStringBuilderImplTest.java
+++ b/src/test/java/br/com/elementalsource/mock/infra/component/impl/QueryStringBuilderImplTest.java
@@ -1,7 +1,12 @@
 package br.com.elementalsource.mock.infra.component.impl;
 
 import br.com.elementalsource.mock.infra.component.ConvertJson;
+
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
@@ -10,6 +15,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryStringBuilderImplTest {
@@ -23,7 +31,7 @@ public class QueryStringBuilderImplTest {
     @Test
     public void shouldBeEmpty() {
         // given
-        final ImmutableMap<String, String> queryMap = ImmutableMap.<String, String>builder().build();
+        final ImmutableMultimap<String, String> queryMap = ImmutableMultimap.<String,String>builder().build();
 
         // when
         final String queryString = queryStringBuilder.fromMap(queryMap);
@@ -36,7 +44,7 @@ public class QueryStringBuilderImplTest {
     @Test
     public void shouldHaveOneParameter() {
         // given
-        final ImmutableMap<String, String> queryMap = ImmutableMap.<String, String>builder().put("name", "Paul").build();
+        final ImmutableMultimap<String, String> queryMap = ImmutableMultimap.<String,String>builder().put("name", "Paul").build();
 
         // when
         final String queryString = queryStringBuilder.fromMap(queryMap);
@@ -50,7 +58,7 @@ public class QueryStringBuilderImplTest {
     @Test
     public void shouldHaveTwoParameters() {
         // given
-        final ImmutableMap<String, String> queryMap = ImmutableMap.<String, String>builder().put("name", "Paul").put("age", "10").build();
+        final ImmutableMultimap<String, String> queryMap = ImmutableMultimap.<String,String>builder().put("name", "Paul").put("age", "10").build();
 
         // when
         final String queryString = queryStringBuilder.fromMap(queryMap);


### PR DESCRIPTION
## Changelog

- Suporte a parâmetros com múltiplos valores no req/resp
- Suporte a múltiplas configurações simultâneas 
  - Permite usar um sufixo em cada config
  - Permite criar pastas para cada config dentro da pasta de resultados
- Adiciona um producer padronizado para GSON